### PR TITLE
feat(front/home): implementar pagina inicial

### DIFF
--- a/myfavgeo-frontend/app/page.tsx
+++ b/myfavgeo-frontend/app/page.tsx
@@ -1,65 +1,21 @@
-import Image from "next/image";
+import { ComoFuncionaSection } from "@/components/layout/Home/ComoFuncionaSection";
+import { Hero } from "@/components/layout/Home/Hero";
+import { FuncionalidadesSection } from "@/components/layout/Home/FuncionalidadesSection";
+import { TecnologiasSection } from "@/components/layout/Home/TecnologiasSection";
+import { CtaSection } from "@/components/layout/Home/CtaSection";
+import { BackgroundBlobs } from "@/components/layout/Home/BackgroundBlobs";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+    <div className="relative min-h-screen overflow-hidden">
+      <BackgroundBlobs />
+      <div className="relative z-10">
+        <Hero />
+        <FuncionalidadesSection />
+        <ComoFuncionaSection />
+        <TecnologiasSection />
+        <CtaSection />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Objetivo
Substituir a página inicial padrão do Next.js pela implementação completa da Home Page, utilizando os componentes padronizados.

## Mudanças
- Adicionado/atualizado:
  - [app/page.tsx](app/page.tsx)

## Impacto
- A rota `/` agora exibe a Landing Page correta da aplicação.

## Testes
1. `npm run dev`
2. Acessar `http://localhost:3000/`
3. Verificar se a Home Page é carregada com Hero, Funcionalidades, etc. (TUDO OK)

Closes #13 