### PR TITLE
Chore(env): Centraliza a URL base da API em variáveis de ambiente no front

### DIFF
--- a/myfavgeo-frontend/next.config.mjs
+++ b/myfavgeo-frontend/next.config.mjs
@@ -16,7 +16,7 @@ const nextConfig = {
     return [
       {
         source: "/api/:path*",
-        destination: "http://backend:8000/api/:path*",
+        destination: `"${process.env.NEXT_PUBLIC_API_URL}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Objetivo
Manter a configuração de URL da API centralizada em variáveis de ambiente

## Mudanças
- **`nex.config`**: substitui a url padrão por variável de ambiente